### PR TITLE
Update akka to 2.6 and other minor dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ project/target
 .metals
 .vscode
 metals.sbt
+.bsp

--- a/akka/build.sbt
+++ b/akka/build.sbt
@@ -7,16 +7,14 @@ Defaults.itSettings
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % versions.typesafeConfig,
   "com.typesafe.akka" %% "akka-actor" % versions.akka,
-
   "org.apache.kafka" % "kafka-clients" % versions.kafka,
   "org.slf4j" % "slf4j-api" % versions.slf4j,
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-
   "org.slf4j" % "log4j-over-slf4j" % versions.slf4j % "test",
   "com.typesafe.akka" %% "akka-testkit" % versions.akka % "test",
   "com.typesafe.akka" %% "akka-slf4j" % versions.akka % "test",
   "org.scalatest" %% "scalatest" % versions.scalaTest % "test",
-  "org.scalatestplus" %% "mockito-1-10" % "3.1.0.0" % "test",
-  "org.mockito" % "mockito-core" % "3.2.11" % "test",
+  "org.scalatestplus" %% "mockito-3-4" % "3.2.9.0" % "test",
+  "org.mockito" % "mockito-core" % "3.11.2" % "test",
   "ch.qos.logback" % "logback-classic" % "1.1.3" % "test"
 )

--- a/akka/src/main/scala/cakesolutions/kafka/akka/KafkaConsumerActor.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/KafkaConsumerActor.scala
@@ -512,7 +512,9 @@ private final class KafkaConsumerActorImpl[K: TypeTag, V: TypeTag](
   implicit def toJavaOffsetQuery(
       offsetQuery: Map[TopicPartition, scala.Long]
   ): java.util.Map[TopicPartition, java.lang.Long] =
-    offsetQuery.map { case (tp, time) => tp -> new java.lang.Long(time) }.asJava
+    offsetQuery.map { case (tp, time) =>
+      tp -> java.lang.Long.valueOf(time)
+    }.asJava
 
   type Records = ConsumerRecords[K, V]
 

--- a/akka/src/test/scala/cakesolutions/kafka/akka/ConsumerRecordsSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/ConsumerRecordsSpec.scala
@@ -1,9 +1,11 @@
 package com.pirum.kafka.akka
 
 import com.pirum.kafka.KafkaTopicPartition
-import org.scalatest.{FlatSpecLike, Inside, Matchers}
+import org.scalatest.{Inside}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class ConsumerRecordsSpec extends FlatSpecLike with Matchers with Inside {
+class ConsumerRecordsSpec extends AnyFlatSpecLike with Matchers with Inside {
 
   val partition = KafkaTopicPartition("sometopic", 0)
   val knownInput: ConsumerRecords[String, Int] =

--- a/akka/src/test/scala/cakesolutions/kafka/akka/KafkaIntSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/KafkaIntSpec.scala
@@ -4,14 +4,16 @@ import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import com.pirum.kafka.testkit.KafkaServer
 import org.scalatest.concurrent.Waiters
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfterAll}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpecLike
 
 /** ScalaTest base class for scala-kafka-client-testkit based integration tests
   */
 class KafkaIntSpec(_system: ActorSystem)
     extends TestKit(_system)
     with Waiters
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll {
 

--- a/akka/src/test/scala/cakesolutions/kafka/akka/TrackPartionsSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/TrackPartionsSpec.scala
@@ -19,7 +19,9 @@ import org.apache.kafka.common.serialization.StringDeserializer
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfterAll}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.collection.JavaConverters._
@@ -28,7 +30,7 @@ import scala.util.Random
 
 class TrackPartionsSpec(system_ : ActorSystem)
     extends TestKit(system_)
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with MockitoSugar {

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val commonSettings = Seq(
   crossScalaVersions := Seq("2.12.12", "2.13.5"),
   //  resolvers += "Apache Staging" at "https://repository.apache.org/content/groups/staging/",
   resolvers += Resolver.bintrayRepo("mockito", "maven"),
-  scalacOptions in Compile ++= Seq(
+  Compile / scalacOptions ++= Seq(
     "-encoding",
     "UTF-8",
     "-target:jvm-1.8",
@@ -24,13 +24,13 @@ lazy val commonSettings = Seq(
     case Some((2, 13)) => Seq()
     case _             => Seq("-Xfuture", "-Ywarn-unused-import", "-Ywarn-nullary-unit")
   }),
-  scalacOptions in (Compile, doc) ++= Seq("-groups", "-implicits"),
-  javacOptions in (Compile, doc) ++= Seq("-notimestamp", "-linksource"),
-  parallelExecution in Test := false,
-  parallelExecution in IntegrationTest := true,
+  Compile / doc / scalacOptions ++= Seq("-groups", "-implicits"),
+  Compile / doc / javacOptions ++= Seq("-notimestamp", "-linksource"),
+  Test / parallelExecution := false,
+  IntegrationTest / parallelExecution := true,
   autoAPIMappings := true,
   publishTo := sonatypePublishToBundle.value,
-  publishArtifact in Test := false,
+  Test / publishArtifact := false,
   publishMavenStyle := true,
   licenses := Seq(
     "MIT" -> url(

--- a/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
@@ -26,7 +26,9 @@ object KafkaConsumer {
   implicit def toJavaOffsetQuery(
       offsetQuery: Map[TopicPartition, scala.Long]
   ): java.util.Map[TopicPartition, java.lang.Long] =
-    offsetQuery.map { case (tp, time) => tp -> new java.lang.Long(time) }.asJava
+    offsetQuery.map { case (tp, time) =>
+      tp -> java.lang.Long.valueOf(time)
+    }.asJava
 
   /** Utilities for creating Kafka consumer configurations.
     */

--- a/client/src/main/scala/cakesolutions/kafka/KafkaProducer.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaProducer.scala
@@ -1,7 +1,5 @@
 package com.pirum.kafka
 
-import java.util.concurrent.TimeUnit
-
 import com.pirum.kafka.TypesafeConfigExtensions._
 import com.typesafe.config.Config
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
@@ -18,7 +16,6 @@ import org.apache.kafka.common.serialization.Serializer
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Future, Promise}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
@@ -91,12 +88,6 @@ trait KafkaProducerLike[K, V] {
     * @see Java `KafkaProducer` [[http://kafka.apache.org/0110/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html#close() close]] method
     */
   def close(): Unit
-
-  /** Close this producer.
-    *
-    * @see Java `KafkaProducer` [[http://kafka.apache.org/0110/javadoc/org/apache/kafka/clients/producer/Producer.html#close(long,%20java.util.concurrent.TimeUnit) close]] method
-    */
-  def close(timeout: FiniteDuration): Unit
 }
 
 /** Utilities for creating a Kafka producer.
@@ -288,9 +279,6 @@ final class KafkaProducer[K, V](val producer: JProducer[K, V])
 
   override def close(): Unit =
     producer.close()
-
-  override def close(timeout: FiniteDuration): Unit =
-    producer.close(timeout.toMillis, TimeUnit.MILLISECONDS)
 
   private def producerCallback(promise: Promise[RecordMetadata]): Callback =
     producerCallback(result => promise.complete(result))

--- a/client/src/test/scala/cakesolutions/kafka/KafkaConsumerSpec.scala
+++ b/client/src/test/scala/cakesolutions/kafka/KafkaConsumerSpec.scala
@@ -63,7 +63,7 @@ class KafkaConsumerSpec extends KafkaIntSpec {
     val topic = randomString
     log.info(s"Using topic [$topic] and kafka port [$kafkaPort]")
 
-    val badSerializer = (msg: String) => {
+    val badSerializer = (_: String) => {
       throw new Exception("Serialization failed")
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ object Dependencies {
     val slf4j = "1.7.29"
     val logback = "1.2.3"
     val scalaTest = "3.1.0"
-    val akka = "2.5.32"
+    val akka = "2.6.15"
     val kafka = "2.4.1"
     val typesafeConfig = "1.4.0"
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.5
+sbt.version = 1.5.4

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,4 +1,4 @@
 // DO NOT EDIT! This file is auto-generated.
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8-19-4d9f966b")


### PR DESCRIPTION
We need akka 2.6 upstream for another project, and this update will become mandatory anyway in the future.