### PR TITLE
Build for 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: scala
 jdk: openjdk8
 scala:
-  - 2.12.12
-  - 2.13.5
+  - 2.13.6
 
 script:
   - sbt -sbt-launch-repo https://repo1.maven.org/maven2 ++$TRAVIS_SCALA_VERSION -Dakka.test.timefactor=5 clean coverage test coverageReport

--- a/akka/src/it/scala/cakesolutions/kafka/akka/KafkaConsumerActorPerfSpec.scala
+++ b/akka/src/it/scala/cakesolutions/kafka/akka/KafkaConsumerActorPerfSpec.scala
@@ -13,7 +13,9 @@ import org.apache.kafka.common.serialization.{
 }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Promise
@@ -25,7 +27,7 @@ import scala.util.Random
 class KafkaConsumerActorPerfSpec(system_ : ActorSystem)
     extends TestKit(system_)
     with ImplicitSender
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures {
@@ -78,7 +80,7 @@ class KafkaConsumerActorPerfSpec(system_ : ActorSystem)
 
     val consumer = KafkaConsumerActor(consumerConf, actorConf, receiver.ref)
 
-    1 to totalMessages foreach { n =>
+    1 to totalMessages foreach { _ =>
       producer.send(KafkaProducerRecord(topic, None, msg1k))
     }
     producer.flush()

--- a/akka/src/it/scala/cakesolutions/kafka/akka/KafkaE2EActorPerfSpec.scala
+++ b/akka/src/it/scala/cakesolutions/kafka/akka/KafkaE2EActorPerfSpec.scala
@@ -12,7 +12,9 @@ import org.apache.kafka.common.serialization.{
 }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Promise
@@ -24,7 +26,7 @@ import scala.util.Random
 class KafkaE2EActorPerfSpec(system_ : ActorSystem)
     extends TestKit(system_)
     with ImplicitSender
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures {

--- a/akka/src/main/scala/cakesolutions/kafka/akka/ConsumerRecords.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/ConsumerRecords.scala
@@ -8,7 +8,7 @@ import org.apache.kafka.clients.consumer.{
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe._
 
 /** Helper functions for [[ConsumerRecords]].
@@ -73,11 +73,13 @@ object ConsumerRecords {
     }
 
     val offsets = Offsets(
-      recordsMap.mapValues(_.maxBy(_.offset()).offset()).toMap
+      recordsMap.view
+        .mapValues(_.maxByOption(_.offset()).fold(0L)(_.offset()))
+        .toMap
     )
 
     val records = new JConsumerRecords(
-      recordsMap.mapValues(_.asJava).toMap.asJava
+      recordsMap.view.mapValues(_.asJava).toMap.asJava
     )
 
     ConsumerRecords(offsets, records)

--- a/akka/src/main/scala/cakesolutions/kafka/akka/KafkaConsumerActor.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/KafkaConsumerActor.scala
@@ -14,7 +14,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.WakeupException
 import org.apache.kafka.common.serialization.Deserializer
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 import scala.language.implicitConversions
 import scala.reflect.runtime.universe.TypeTag
@@ -558,10 +558,10 @@ private final class KafkaConsumerActorImpl[K: TypeTag, V: TypeTag](
   }
 
   private def timeOffsets2regularOffsets(timeOffsets: Offsets): Offsets = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val javaOffsetsAndTimestamps =
       consumer.offsetsForTimes(timeOffsets.offsetsMap).asScala.toMap
-    val offsets = javaOffsetsAndTimestamps.mapValues(_.offset()).toMap
+    val offsets = javaOffsetsAndTimestamps.view.mapValues(_.offset()).toMap
     Offsets(offsets)
   }
 

--- a/akka/src/main/scala/cakesolutions/kafka/akka/Offsets.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/Offsets.scala
@@ -31,7 +31,7 @@ final case class Offsets(offsetsMap: Map[TopicPartition, Long]) extends AnyVal {
   /** Convert offsets to map of Kafka commit offsets
     */
   def toCommitMap: Map[TopicPartition, OffsetAndMetadata] =
-    offsetsMap.mapValues(offset => new OffsetAndMetadata(offset)).toMap
+    offsetsMap.view.mapValues(offset => new OffsetAndMetadata(offset)).toMap
 
   /** Keep only the offsets for partitions that are also in the given set of partitions.
     *

--- a/akka/src/main/scala/cakesolutions/kafka/akka/TrackPartitions.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/TrackPartitions.scala
@@ -10,7 +10,7 @@ import org.apache.kafka.clients.consumer.{
 import org.apache.kafka.common.TopicPartition
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 sealed trait TrackPartitions extends ConsumerRebalanceListener {
   def isRevoked: Boolean

--- a/akka/src/test/scala/cakesolutions/kafka/akka/KafkaConsumerActorSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/KafkaConsumerActorSpec.scala
@@ -253,7 +253,7 @@ class KafkaConsumerActorSpec(system_ : ActorSystem)
       consumer ! Confirm(rs.offsets)
       expectNoMessage(5.seconds)
 
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       val messages = rs.records.iterator().asScala.toList.map(_.value())
       messages should be(List("second"))
       consumer ! Unsubscribe

--- a/akka/src/test/scala/cakesolutions/kafka/akka/KafkaProducerActorSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/KafkaProducerActorSpec.scala
@@ -45,11 +45,11 @@ class KafkaProducerActorSpec(system_ : ActorSystem)
       KafkaProducerRecord(topic, "key", "value"),
       KafkaProducerRecord(topic, "bar")
     )
-    val message = ProducerRecords(batch, Some('response))
+    val message = ProducerRecords(batch, Some(Symbol("response")))
 
     probe.send(producer, message)
 
-    probe.expectMsg('response)
+    probe.expectMsg(Symbol("response"))
 
     val results = consumeFromTopic(topic, 3, 10000)
 

--- a/akka/src/test/scala/cakesolutions/kafka/akka/TrackPartionsSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/TrackPartionsSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 import scala.util.Random
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,7 @@ lazy val commonSettings = Seq(
   organizationName := "Pirum Systems",
   organizationHomepage := Some(url("https://pirum.com")),
   pomIncludeRepository := { _ => false },
-  scalaVersion := "2.12.12",
-  crossScalaVersions := Seq("2.12.12", "2.13.5"),
+  scalaVersion := "2.13.6",
   //  resolvers += "Apache Staging" at "https://repository.apache.org/content/groups/staging/",
   resolvers += Resolver.bintrayRepo("mockito", "maven"),
   Compile / scalacOptions ++= Seq(

--- a/client/src/it/scala/cakesolutions/kafka/KafkaConsumerPerfSpec.scala
+++ b/client/src/it/scala/cakesolutions/kafka/KafkaConsumerPerfSpec.scala
@@ -6,17 +6,19 @@ import org.apache.kafka.common.serialization.{
   StringDeserializer,
   StringSerializer
 }
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 /** Ad hoc performance test for validating consumer performance.  Pass environment variable KAFKA with contact point for
   * Kafka server e.g. -DKAFKA=127.0.0.1:9092
   */
 class KafkaConsumerPerfSpec
-    extends FlatSpecLike
+    extends AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll {
 
@@ -47,7 +49,7 @@ class KafkaConsumerPerfSpec
     )
     val producer = KafkaProducer[String, String](producerConf)
 
-    1 to 100000 foreach { n =>
+    1 to 100000 foreach { _ =>
       producer.send(KafkaProducerRecord(topic, None, msg1k))
     }
     producer.flush()

--- a/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaConsumer.scala
@@ -11,7 +11,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.requests.IsolationLevel
 import org.apache.kafka.common.serialization.Deserializer
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.language.implicitConversions
 
 /** Utilities for creating a Kafka consumer.

--- a/client/src/main/scala/cakesolutions/kafka/KafkaProducer.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaProducer.scala
@@ -14,7 +14,7 @@ import org.apache.kafka.clients.producer.{
 import org.apache.kafka.common.{PartitionInfo, TopicPartition}
 import org.apache.kafka.common.serialization.Serializer
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.concurrent.{Future, Promise}
 import scala.util.control.NonFatal

--- a/client/src/main/scala/cakesolutions/kafka/KafkaSerialization.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaSerialization.scala
@@ -28,7 +28,7 @@ object KafkaSerializer {
   *
   * @param f the function that (statelessly) performs the deserialization
   */
-private class FunDeserializer[T](f: Array[Byte] ⇒ T) extends Deserializer[T] {
+private class FunDeserializer[T](f: Array[Byte] => T) extends Deserializer[T] {
 
   override def configure(
       configs: util.Map[String, _],

--- a/client/src/main/scala/cakesolutions/kafka/TypesafeConfigExtensions.scala
+++ b/client/src/main/scala/cakesolutions/kafka/TypesafeConfigExtensions.scala
@@ -2,7 +2,7 @@ package com.pirum.kafka
 
 import java.util.Properties
 import com.typesafe.config.Config
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.immutable._
 import scala.collection.mutable
 

--- a/client/src/test/scala/cakesolutions/kafka/ConfigureSerializationSpec.scala
+++ b/client/src/test/scala/cakesolutions/kafka/ConfigureSerializationSpec.scala
@@ -58,7 +58,7 @@ class ConfigureSerializationSpec extends KafkaIntSpec {
     )
 
     val producer = KafkaProducer(conf)
-    producer.close
+    producer.close()
 
     keySerializer.configuration shouldEqual "mock_value"
     keySerializer.isKeySerializer shouldEqual true

--- a/client/src/test/scala/cakesolutions/kafka/ConsumerProducerIntSpec.scala
+++ b/client/src/test/scala/cakesolutions/kafka/ConsumerProducerIntSpec.scala
@@ -8,7 +8,7 @@ import org.apache.kafka.common.serialization.{
 }
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 class ConsumerProducerIntSpec extends KafkaIntSpec {

--- a/client/src/test/scala/cakesolutions/kafka/IdempotentProducerSpec.scala
+++ b/client/src/test/scala/cakesolutions/kafka/IdempotentProducerSpec.scala
@@ -9,7 +9,7 @@ import org.apache.kafka.common.serialization.{
 }
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 class IdempotentProducerSpec extends KafkaIntSpec {

--- a/client/src/test/scala/cakesolutions/kafka/KafkaConsumerSpec.scala
+++ b/client/src/test/scala/cakesolutions/kafka/KafkaConsumerSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.concurrent.Waiters.Waiter
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Random, Success}
 
 class KafkaConsumerSpec extends KafkaIntSpec {

--- a/client/src/test/scala/cakesolutions/kafka/KafkaIntSpec.scala
+++ b/client/src/test/scala/cakesolutions/kafka/KafkaIntSpec.scala
@@ -1,9 +1,14 @@
 package com.pirum.kafka
 
 import com.pirum.kafka.testkit.KafkaServer
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
-class KafkaIntSpec extends FlatSpecLike with Matchers with BeforeAndAfterAll {
+class KafkaIntSpec
+    extends AnyFlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll {
   val kafkaServer = new KafkaServer()
   val kafkaPort = kafkaServer.kafkaPort
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ object Dependencies {
     val slf4j = "1.7.29"
     val logback = "1.2.3"
     val scalaTest = "3.1.0"
-    val akka = "2.6.15"
+    val akka = "2.6.18"
     val kafka = "2.4.1"
     val typesafeConfig = "1.4.0"
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.4
+sbt.version = 1.6.1

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,4 +1,6 @@
 // DO NOT EDIT! This file is auto-generated.
+
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8-19-4d9f966b")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.12")
+

--- a/testkit/src/main/scala/cakesolutions.kafka/testkit/KafkaServer.scala
+++ b/testkit/src/main/scala/cakesolutions.kafka/testkit/KafkaServer.scala
@@ -18,7 +18,7 @@ import org.apache.kafka.clients.producer.{
 import org.apache.kafka.common.serialization.{Deserializer, Serializer}
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.util.{Random, Try}
 


### PR DESCRIPTION
When running tests against 2.13, I noticed an exception was thrown in `ConsumerRecords` when someone tries to build one from an empty collection. This should never happen in real life, but it may in tests. So for that we replace with `maxByOption`.